### PR TITLE
GizmoPickup SpawnGroup and SpawnType properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,11 +147,11 @@ sourceSets {
         }
     }
 
-    test{
+    /*test{
         java{
             srcDirs = ['test']
         }
-    }
+    }*/
 }
 
 test{

--- a/src/com/opengg/loader/game/nu2/gizmo/GizLoader.java
+++ b/src/com/opengg/loader/game/nu2/gizmo/GizLoader.java
@@ -5,6 +5,7 @@ import com.opengg.core.math.Vector3f;
 import com.opengg.loader.BrickBench;
 import com.opengg.loader.Util;
 import com.opengg.loader.game.nu2.NU2MapData;
+import com.opengg.loader.game.nu2.gizmo.Gizmo.GizPickup.SpawnType;
 import com.opengg.loader.game.nu2.scene.SpecialObject;
 
 import java.nio.ByteBuffer;
@@ -582,11 +583,11 @@ public class GizLoader {
                     version = fileData.getInt();
                     gizCount = fileData.getInt();
                     if (version >= 3) {
-                        fileData.getInt();
+                        fileData.getInt(); //prequel levels have 1, og trilogy has 3?
                     }
                     if (version >= 5) {
-                        fileData.getFloat();
-                        fileData.getFloat();
+                        fileData.getFloat(); //draw distance
+                        fileData.getFloat(); //scale (applies to entire area)
                     }
                     for (int i = 0; i < gizCount; i++) {
                         int address = fileData.position();
@@ -613,15 +614,19 @@ public class GizLoader {
                             default -> Gizmo.GizPickup.PickupType.UNKNOWN;
                         };
 
-                        //Both likely padding
-                        if (version >= 2) {
-                            fileData.get();
+                        int spawnGroup=0;
+                        byte spawnType=0;
+                        //pickup spawn type? (used mostly for minikits that spawn after doing something)
+                        if (version >= 2) { 
+                            spawnType = fileData.get();
                         }
-                        if (version >= 3) {
-                            fileData.get();
+                        //pickup spawn group (make multiple pickups of same group spawn at same time, unused but works in TCS)
+                        if (version >= 3) { 
+                            spawnGroup = fileData.get();
                         }
 
-                        mapData.gizmo().gizmos().add(new Gizmo.GizPickup(pickupName, pos, realType, address, fileData.position() - address, i));
+                        mapData.gizmo().gizmos().add(new Gizmo.GizPickup(pickupName, pos, realType,version,
+                        spawnGroup,SpawnType.getType(spawnType), address, fileData.position() - address, i));
                     }
                 }
                 case "Lever" -> {

--- a/src/com/opengg/loader/game/nu2/gizmo/GizWriter.java
+++ b/src/com/opengg/loader/game/nu2/gizmo/GizWriter.java
@@ -75,7 +75,7 @@ public class GizWriter {
 
             gizmoName = "Pup_" + gizmoData.gizCount;
             newGizmo = ByteBuffer.allocate(newGizLength).order(ByteOrder.LITTLE_ENDIAN).put(Util.getStringBytes(gizmoName, 8))
-                   .put(BrickBench.CURRENT.ingamePosition.toLittleEndianByteBuffer()).put((byte)115).rewind();
+                   .put(BrickBench.CURRENT.ingamePosition.toLittleEndianByteBuffer()).put((byte)115).put((byte)0).put((byte)0).rewind().slice(0,newGizLength);
 
             gizmoCountPosition = gizmoData.start + 4;
         }else if(type.equals("ZipUp")){


### PR DESCRIPTION
This pull request includes a change to build.gradle because that was the only way I figured out to test and I couldn't figure out how to remove the commit from the pull request.

Added spawn group property for version 3+ pickups. Spawn group can be used to spawn multiple pickups at once, ex. only letting some studs spawn until after a minikit is spawned in by setting their group to the same number.

Added spawn type property for version 2+ pickups. This property is an enum where "none" is normal pickups, "triggered" is used on most minikits that spawn in, and "auto_collect" lets pickups be automatically collected when they spawn in / are triggered, like minikits in vehicle/flying levels.